### PR TITLE
Fixed potential torn reads in EventCounter

### DIFF
--- a/src/BlazingPizza.Orders/OrdersEventSource.cs
+++ b/src/BlazingPizza.Orders/OrdersEventSource.cs
@@ -30,7 +30,7 @@ namespace BlazingPizza.Orders
         {
             if (command.Command == EventCommand.Enable)
             {
-                _totalOrdersCounter ??= new PollingCounter("total-orders", this, () => Volatile.Read(ref _totalOrders))
+                _totalOrdersCounter ??= new PollingCounter("total-orders", this, () => Interlocked.Read(ref _totalOrders))
                 {
                     DisplayName = "Total Orders"
                 };

--- a/src/BlazingPizza.Orders/OrdersEventSource.cs
+++ b/src/BlazingPizza.Orders/OrdersEventSource.cs
@@ -30,7 +30,7 @@ namespace BlazingPizza.Orders
         {
             if (command.Command == EventCommand.Enable)
             {
-                _totalOrdersCounter ??= new PollingCounter("total-orders", this, () => _totalOrders)
+                _totalOrdersCounter ??= new PollingCounter("total-orders", this, () => Volatile.Read(ref _totalOrders))
                 {
                     DisplayName = "Total Orders"
                 };


### PR DESCRIPTION
The backing fields for the counter is `long`, so there was potential torn read on 32-bit platforms.
`Volatile.Read` ensures that the value is read in a atomic way, so no torn reads can occur.